### PR TITLE
Build & install packages in the base image

### DIFF
--- a/docker/build
+++ b/docker/build
@@ -1,2 +1,1 @@
-ABSDIR=$(dirname $(readlink -f $0))
-docker build -t docker_noahbot $ABSDIR
+(cd .. && docker build -t docker_noahbot -f docker/dockerfile .)

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,5 +1,24 @@
 FROM osrf/ros:noetic-desktop-full
 
-RUN apt-get update
+
+RUN apt-get update && apt-get dist-upgrade --yes
+
+RUN mkdir -p /home/catkin_ws/src
+
+WORKDIR /home/catkin_ws/src
+
+COPY move_base_utils move_base_utils
+COPY noah_2dnav noah_2dnav
+COPY noah_control noah_control
+COPY noah_description noah_description
+COPY noah_gazebo noah_gazebo
+COPY noah_rtabmap noah_rtabmap
+COPY noah_rviz noah_rviz
+
+WORKDIR /home/catkin_ws
+
+RUN rosdep install --from-paths src --ignore-src -r -y
+
+RUN . /opt/ros/noetic/setup.sh && catkin_make
 
 CMD ["/bin/echo", ""]


### PR DESCRIPTION
This allows to build the base image, install the deps and have everything ready and installed in the image itself. The steps in the README are still required (but will be a lot faster, since most of it, if not all, will be cached) in order to safely run this project.

Please feel free to dismiss, I needed this to perform multiple builds & runs (and make it fast).